### PR TITLE
re-added warp command enable switch

### DIFF
--- a/src/com/massivecraft/factions/cmd/CmdFactionsWarpAdd.java
+++ b/src/com/massivecraft/factions/cmd/CmdFactionsWarpAdd.java
@@ -37,6 +37,12 @@ public class CmdFactionsWarpAdd extends FactionsCommandWarp
 	@Override
 	public void perform() throws MassiveException
 	{
+		if ( ! MConf.get().warpsCommandEnabled)
+		{
+			msender.msg("<b>Sorry, the ability to warp is disabled on this server.");
+			return;
+		}
+
 		// Args
 		String name = this.readArg();
 		Faction faction = this.readArg(msenderFaction);

--- a/src/com/massivecraft/factions/cmd/CmdFactionsWarpGo.java
+++ b/src/com/massivecraft/factions/cmd/CmdFactionsWarpGo.java
@@ -48,6 +48,12 @@ public class CmdFactionsWarpGo extends FactionsCommandWarp
 	@Override
 	public void perform() throws MassiveException
 	{
+		if ( ! MConf.get().warpsCommandEnabled)
+		{
+			msender.msg("<b>Sorry, the ability to warp is disabled on this server.");
+			return;
+		}
+
 		// Args
 		Faction faction = this.readArgAt(1, msenderFaction);
 		Warp warp = TypeWarp.get(faction).read(this.argAt(0), sender);

--- a/src/com/massivecraft/factions/cmd/CmdFactionsWarpList.java
+++ b/src/com/massivecraft/factions/cmd/CmdFactionsWarpList.java
@@ -31,6 +31,12 @@ public class CmdFactionsWarpList extends FactionsCommandWarp
 	@Override
 	public void perform() throws MassiveException
 	{
+		if ( ! MConf.get().warpsCommandEnabled)
+		{
+			msender.msg("<b>Sorry, the ability to warp is disabled on this server.");
+			return;
+		}
+
 		// Args
 		Faction faction = this.readArg(msenderFaction);
 		int idx = this.readArg();

--- a/src/com/massivecraft/factions/cmd/CmdFactionsWarpRemove.java
+++ b/src/com/massivecraft/factions/cmd/CmdFactionsWarpRemove.java
@@ -28,6 +28,12 @@ public class CmdFactionsWarpRemove extends FactionsCommandWarp
 	@Override
 	public void perform() throws MassiveException
 	{
+		if ( ! MConf.get().warpsCommandEnabled)
+		{
+			msender.msg("<b>Sorry, the ability to warp is disabled on this server.");
+			return;
+		}
+
 		// Args
 		Faction faction = this.readArgAt(1, msenderFaction);
 		Warp warp = TypeWarp.get(faction).read(this.argAt(0), sender);

--- a/src/com/massivecraft/factions/entity/MConf.java
+++ b/src/com/massivecraft/factions/entity/MConf.java
@@ -254,6 +254,10 @@ public class MConf extends Entity<MConf>
 	// It's usually a wise idea keeping this true.
 	// Otherwise players can set their warps inside enemy territory.
 	public boolean warpsMustBeInClaimedTerritory = true;
+
+	// Is the warp command available?
+	// One reason you might set this to false is if you only want players going home on respawn after death.
+	public boolean warpsCommandEnabled = true;
 	
 	// These options can be used to limit rights to warp under different circumstances.
 	public boolean warpsTeleportAllowedFromEnemyTerritory = true;


### PR DESCRIPTION
The old option:
```
// Is the home teleport command available?
// One reason you might set this to false is if you only want players going home on respawn after death.
"homesTeleportCommandEnabled": true,
```
was removed. This was a feature I used, so I re-added it as `warpsCommandEnabled`.

Why was this removed? Can we re-add it?

Also, I had trouble compiling the project, so it's untested ATM.
```
[ERROR] Failed to execute goal on project Factions: Could not resolve dependencies for project com.massivecraft.factions:Factions:jar:3.2.2: Failed to collect dependencies at com.massivecraft.massivecore:MassiveCore:jar:3.2.2: Failed to read artifact descriptor for com.massivecraft.massivecore:MassiveCore:jar:3.2.2: Could not transfer artifact com.massivecraft.massivesuper:MassiveSuper:pom:3.2.2 from/to destroystokyo-repo (https://repo.destroystokyo.com/repository/maven-snapshots/): Failed to transfer file https://repo.destroystokyo.com/repository/maven-snapshots/com/massivecraft/massivesuper/MassiveSuper/3.2.2/MassiveSuper-3.2.2.pom with status code 400
```